### PR TITLE
Static attributes

### DIFF
--- a/estree/src/js_node_type.rs
+++ b/estree/src/js_node_type.rs
@@ -4,6 +4,7 @@ pub enum JsNodeType {
     BlockStatement,
     CallExpression,
     MemberExpression,
+    ObjectExpression,
     StringLiteral,
     NullLiteral,
     VariableDeclaration,

--- a/estree/src/lib.rs
+++ b/estree/src/lib.rs
@@ -5,6 +5,7 @@ pub mod identifier;
 pub mod js_node_type;
 pub mod member_expression;
 pub mod null_literal;
+pub mod object_expression;
 pub mod return_statement;
 pub mod string_literal;
 pub mod variable_declaration;
@@ -16,6 +17,7 @@ use function_declaration::FunctionDeclaration;
 use identifier::Identifier;
 use member_expression::MemberExpression;
 use null_literal::NullLiteral;
+use object_expression::ObjectExpression;
 use return_statement::ReturnStatement;
 use string_literal::StringLiteral;
 use variable_declaration::VariableDeclaration;
@@ -32,6 +34,7 @@ pub trait JsVisitor<T> {
     fn visit_variable_declaration(&self, variable_declaration: &VariableDeclaration) -> T;
     fn visit_variable_declarator(&self, variable_declarator: &VariableDeclarator) -> T;
     fn visit_null_literal(&self, null_literal: &NullLiteral) -> T;
+    fn visit_object_expression(&self, object_expression: &ObjectExpression) -> T;
 }
 
 #[derive(Debug, PartialEq)]
@@ -46,6 +49,7 @@ pub enum JsNode {
     VariableDeclaration(VariableDeclaration),
     VariableDeclarator(VariableDeclarator),
     NullLiteral(NullLiteral),
+    ObjectExpression(ObjectExpression),
 }
 
 impl JsNode {
@@ -71,6 +75,9 @@ impl JsNode {
                 visitor.visit_variable_declarator(variable_declarator)
             }
             Self::NullLiteral(null_literal) => visitor.visit_null_literal(null_literal),
+            Self::ObjectExpression(object_expression) => {
+                visitor.visit_object_expression(object_expression)
+            }
         }
     }
 }

--- a/estree/src/object_expression.rs
+++ b/estree/src/object_expression.rs
@@ -1,0 +1,16 @@
+use crate::{JsNode, js_node_type::JsNodeType};
+
+#[derive(Debug, PartialEq)]
+pub struct ObjectExpression {
+    pub js_node_type: JsNodeType,
+    pub properties: Vec<JsNode>,
+}
+
+impl ObjectExpression {
+    pub fn new(properties: Vec<JsNode>) -> Self {
+        Self {
+            js_node_type: JsNodeType::ObjectExpression,
+            properties,
+        }
+    }
+}

--- a/parser/src/token_buffer.rs
+++ b/parser/src/token_buffer.rs
@@ -1,27 +1,31 @@
 use lexer::Lexer;
-use std::cell::{Ref, RefCell};
-use token::Token;
+use std::mem::replace;
+use token::{Token, TokenType};
 
 #[derive(Debug)]
 pub struct TokenBuffer {
     lexer: Lexer,
-    token: RefCell<Token>,
+    token: Token,
 }
 
 impl TokenBuffer {
     pub fn new(input: &str) -> Self {
         let lexer = Lexer::new(input);
-        let token = RefCell::new(lexer.token());
+        let token = lexer.token();
 
         Self { lexer, token }
     }
 
-    pub fn next(&self) -> Token {
-        self.token.replace(self.lexer.token())
+    pub fn next(&mut self) -> Token {
+        replace(&mut self.token, self.lexer.token())
     }
 
-    pub fn peek(&self) -> Ref<'_, Token> {
-        self.token.borrow()
+    pub fn peek(&self) -> &Token {
+        &self.token
+    }
+
+    pub fn peek_token_type(&self) -> TokenType {
+        TokenType::from(&self.token)
     }
 }
 
@@ -31,7 +35,7 @@ mod token_buffer {
 
     #[test]
     fn get_and_consume_next_token() {
-        let token_buffer = TokenBuffer::new("div {}");
+        let mut token_buffer = TokenBuffer::new("div {}");
 
         assert_eq!(Token::Div, token_buffer.next());
         assert_eq!(Token::LeftBrace, token_buffer.next());
@@ -43,12 +47,12 @@ mod token_buffer {
     fn peek_current_token() {
         let token_buffer = TokenBuffer::new("div {}");
 
-        assert_eq!(Token::Div, *token_buffer.peek());
-        assert_eq!(Token::Div, *token_buffer.peek());
+        assert_eq!(&Token::Div, token_buffer.peek());
+        assert_eq!(&Token::Div, token_buffer.peek());
     }
 
     #[test]
     fn new() {
-        assert_eq!(Token::End, *TokenBuffer::new("").token.borrow());
+        assert_eq!(Token::End, TokenBuffer::new("").token);
     }
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -2,11 +2,13 @@
 pub enum Proto {
     Element(Element),
     Literal(String),
+    Attribute(Attribute),
 }
 
 pub trait ProtoVisitor<T> {
     fn visit_element(&self, element: &Element) -> T;
     fn visit_literal(&self, literal: &String) -> T;
+    fn visit_attribute(&self, attribute: &Attribute) -> T;
 }
 
 #[derive(Debug, PartialEq)]
@@ -24,11 +26,27 @@ impl Element {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub struct Attribute {
+    name: String,
+    value: Box<Proto>,
+}
+
+impl Attribute {
+    pub fn new(name: &str, value: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            value: Box::new(Proto::Literal(value.to_string())),
+        }
+    }
+}
+
 impl Proto {
     pub fn accept<T>(&self, visitor: &impl ProtoVisitor<T>) -> T {
         match self {
             Self::Element(element) => visitor.visit_element(element),
             Self::Literal(string) => visitor.visit_literal(string),
+            Self::Attribute(attribute) => visitor.visit_attribute(attribute),
         }
     }
 }

--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -5,6 +5,8 @@ pub enum TokenType {
     Div,
     Span,
     Literal,
+    Attribute,
+    Equal,
     LeftBrace,
     RightBrace,
     Error,
@@ -16,7 +18,9 @@ impl Display for TokenType {
         match self {
             Self::Div => write!(f, "\"div\""),
             Self::Span => write!(f, "\"span\""),
+            Self::Attribute => write!(f, "attribute"),
             Self::Literal => write!(f, "literal"),
+            Self::Equal => write!(f, "="),
             Self::LeftBrace => write!(f, "{{"),
             Self::RightBrace => write!(f, "}}"),
             Self::Error => write!(f, "error"),
@@ -29,7 +33,9 @@ impl Display for TokenType {
 pub enum Token {
     Div,
     Span,
+    Attribute(String),
     Literal(String),
+    Equal,
     LeftBrace,
     RightBrace,
     Error,
@@ -41,6 +47,8 @@ impl From<&Token> for TokenType {
         match token {
             Token::Div => TokenType::Div,
             Token::Span => TokenType::Span,
+            Token::Attribute(_) => TokenType::Attribute,
+            Token::Equal => TokenType::Equal,
             Token::Literal(_) => TokenType::Literal,
             Token::LeftBrace => TokenType::LeftBrace,
             Token::RightBrace => TokenType::RightBrace,


### PR DESCRIPTION
Add static/non-function expression attributes to language.

```
div {
    @id="main"
    @class="flex"
    @style="padding: 20px
    ...
}
```

The browser controls Element attributes, meaning that if you add `method="POST"` to a `div`, the browser will not append it. This makes it much easier to handle! Elements with no attributes will return an empty object and not null - something to consider when creating the runtime.

Attributes like the following will be dealt with later when adding variables and scope.
```
div {
    @onclick=|event| event
}
```