### PR TITLE
Token literals

### DIFF
--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -70,15 +70,7 @@ impl Lexer {
                 }
 
                 match self.input.get(self.start.get()..self.current.get()) {
-                    Some(word) => match word.into_iter().collect::<String>().as_str() {
-                        "div" => Token::Div,
-                        "span" => Token::Span,
-                        "form" => Token::Form,
-                        "input" => Token::Input,
-                        "p" => Token::P,
-                        "button" => Token::Button,
-                        _ => return Token::Error,
-                    },
+                    Some(word) => Token::Identifier(word.into_iter().collect()),
                     _ => return Token::Error,
                 }
             }
@@ -117,7 +109,7 @@ mod lexer {
     fn tokenize_strings() {
         let lexer = Lexer::new(r#"div {"Hello, 🌎!"}"#);
 
-        assert_eq!(Token::Div, lexer.token());
+        assert_eq!(Token::Identifier("div".to_string()), lexer.token());
         assert_eq!(Token::LeftBrace, lexer.token());
         assert_eq!(Token::Literal("\"Hello, 🌎!\"".to_string()), lexer.token());
         assert_eq!(Token::RightBrace, lexer.token());
@@ -128,7 +120,7 @@ mod lexer {
     fn tokenize_input() {
         let lexer = Lexer::new("div {}");
 
-        assert_eq!(Token::Div, lexer.token());
+        assert_eq!(Token::Identifier("div".to_string()), lexer.token());
         assert_eq!(Token::LeftBrace, lexer.token());
         assert_eq!(Token::RightBrace, lexer.token());
         assert_eq!(Token::End, lexer.token());
@@ -142,9 +134,18 @@ mod lexer {
 
     #[test]
     fn identify_keywords() {
-        assert_eq!(Token::Div, Lexer::new("div").scan());
-        assert_eq!(Token::Span, Lexer::new("span").scan());
-        assert_eq!(Token::Error, Lexer::new("something").scan());
+        assert_eq!(
+            Token::Identifier("div".to_string()),
+            Lexer::new("div").scan()
+        );
+        assert_eq!(
+            Token::Identifier("span".to_string()),
+            Lexer::new("span").scan()
+        );
+        assert_eq!(
+            Token::Identifier("something".to_string()),
+            Lexer::new("something").scan()
+        );
     }
 
     #[test]

--- a/parser/src/html_tag.rs
+++ b/parser/src/html_tag.rs
@@ -2,6 +2,32 @@ use crate::parser_error::ParserError;
 use std::fmt::Display;
 
 #[derive(Debug)]
+pub struct HtmlElementFactory {
+    id: usize,
+}
+
+impl HtmlElementFactory {
+    pub fn new() -> Self {
+        Self { id: 0 }
+    }
+
+    pub fn create(&mut self, tag_type: &str) -> Result<HtmlElement, ParserError> {
+        self.id += 1;
+
+        Ok(HtmlElement {
+            id: self.id,
+            html_tag: HtmlTag::try_from(tag_type)?,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct HtmlElement {
+    pub id: usize,
+    pub html_tag: HtmlTag,
+}
+
+#[derive(Debug)]
 pub enum HtmlTag {
     P,
     Form,

--- a/parser/src/html_tag.rs
+++ b/parser/src/html_tag.rs
@@ -1,0 +1,42 @@
+use crate::parser_error::ParserError;
+use std::fmt::Display;
+
+#[derive(Debug)]
+pub enum HtmlTag {
+    P,
+    Form,
+    Input,
+    Button,
+    Div,
+    Span,
+}
+
+impl TryFrom<&str> for HtmlTag {
+    type Error = ParserError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "div" => Ok(HtmlTag::Div),
+            "span" => Ok(HtmlTag::Span),
+            "form" => Ok(HtmlTag::Form),
+            "input" => Ok(HtmlTag::Input),
+            "button" => Ok(HtmlTag::Button),
+            "p" => Ok(HtmlTag::P),
+            _ => return Err(ParserError::UnknownElement),
+        }
+    }
+}
+
+impl Display for HtmlTag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let html_tag = match self {
+            HtmlTag::P => String::from("p"),
+            HtmlTag::Form => String::from("form"),
+            HtmlTag::Input => String::from("input"),
+            HtmlTag::Button => String::from("button"),
+            HtmlTag::Div => String::from("div"),
+            HtmlTag::Span => String::from("span"),
+        };
+        write!(f, "\"{}\"", html_tag)
+    }
+}

--- a/parser/src/parser_error.rs
+++ b/parser/src/parser_error.rs
@@ -4,6 +4,7 @@ use std::{error::Error, fmt::Display};
 pub enum ParserError {
     UnexpectedToken,
     UnknownAttribute,
+    UnknownElement,
 }
 
 impl Error for ParserError {}
@@ -13,6 +14,7 @@ impl Display for ParserError {
         match self {
             ParserError::UnexpectedToken => write!(f, "Unexpected token"),
             ParserError::UnknownAttribute => write!(f, "Unknown attribute"),
+            ParserError::UnknownElement => write!(f, "Unknown element"),
         }
     }
 }

--- a/parser/src/token_buffer.rs
+++ b/parser/src/token_buffer.rs
@@ -37,7 +37,7 @@ mod token_buffer {
     fn get_and_consume_next_token() {
         let mut token_buffer = TokenBuffer::new("div {}");
 
-        assert_eq!(Token::Div, token_buffer.next());
+        assert_eq!(Token::Identifier("div".to_string()), token_buffer.next());
         assert_eq!(Token::LeftBrace, token_buffer.next());
         assert_eq!(Token::RightBrace, token_buffer.next());
         assert_eq!(Token::End, token_buffer.next());
@@ -47,8 +47,8 @@ mod token_buffer {
     fn peek_current_token() {
         let token_buffer = TokenBuffer::new("div {}");
 
-        assert_eq!(&Token::Div, token_buffer.peek());
-        assert_eq!(&Token::Div, token_buffer.peek());
+        assert_eq!(&Token::Identifier("div".to_string()), token_buffer.peek());
+        assert_eq!(&Token::Identifier("div".to_string()), token_buffer.peek());
     }
 
     #[test]

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -13,14 +13,21 @@ pub trait ProtoVisitor<T> {
 
 #[derive(Debug, PartialEq)]
 pub struct Element {
+    pub element_id: usize,
     pub element_type: String,
     pub attributes: Vec<Proto>,
     pub children: Vec<Proto>,
 }
 
 impl Element {
-    pub fn new(element_type: &str, attributes: Vec<Proto>, children: Vec<Proto>) -> Self {
+    pub fn new(
+        element_id: usize,
+        element_type: &str,
+        attributes: Vec<Proto>,
+        children: Vec<Proto>,
+    ) -> Self {
         Self {
+            element_id,
             element_type: String::from(element_type),
             attributes,
             children,

--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -2,30 +2,20 @@ use std::fmt::Display;
 
 #[derive(Debug, PartialEq)]
 pub enum TokenType {
-    P,
-    Form,
-    Input,
-    Button,
-    Div,
-    Span,
-    Literal,
-    Attribute,
     Equal,
     LeftBrace,
     RightBrace,
+    Identifier,
+    Literal,
+    Attribute,
     Error,
     End,
 }
 
+// Remove in future
 impl Display for TokenType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::P => write!(f, "\"p\""),
-            Self::Form => write!(f, "\"form\""),
-            Self::Input => write!(f, "\"input\""),
-            Self::Button => write!(f, "\"button\""),
-            Self::Div => write!(f, "\"div\""),
-            Self::Span => write!(f, "\"span\""),
             Self::Attribute => write!(f, "attribute"),
             Self::Literal => write!(f, "literal"),
             Self::Equal => write!(f, "="),
@@ -33,20 +23,16 @@ impl Display for TokenType {
             Self::RightBrace => write!(f, "}}"),
             Self::Error => write!(f, "error"),
             Self::End => write!(f, "end"),
+            Self::Identifier => write!(f, "identifier"),
         }
     }
 }
 
 #[derive(Debug, PartialEq)]
 pub enum Token {
-    P,
-    Form,
-    Input,
-    Button,
-    Div,
-    Span,
     Attribute(String),
     Literal(String),
+    Identifier(String),
     Equal,
     LeftBrace,
     RightBrace,
@@ -57,19 +43,14 @@ pub enum Token {
 impl From<&Token> for TokenType {
     fn from(token: &Token) -> Self {
         match token {
-            Token::Div => TokenType::Div,
-            Token::Span => TokenType::Span,
             Token::Attribute(_) => TokenType::Attribute,
+            Token::Identifier(_) => TokenType::Identifier,
             Token::Equal => TokenType::Equal,
             Token::Literal(_) => TokenType::Literal,
             Token::LeftBrace => TokenType::LeftBrace,
             Token::RightBrace => TokenType::RightBrace,
             Token::Error => TokenType::Error,
             Token::End => TokenType::End,
-            Token::P => TokenType::P,
-            Token::Form => TokenType::Form,
-            Token::Input => TokenType::Input,
-            Token::Button => TokenType::Button,
         }
     }
 }

--- a/transpiler/src/lib.rs
+++ b/transpiler/src/lib.rs
@@ -120,6 +120,7 @@ mod transpiler {
                 ))]),
             )),
             Transpiler.transpile(&Proto::Element(Element::new(
+                1,
                 "div",
                 vec![Proto::Attribute(Attribute::new("style", "\"color: red;\"")),],
                 vec![],
@@ -150,9 +151,10 @@ mod transpiler {
                 ))]),
             )),
             Transpiler.transpile(&Proto::Element(Element::new(
+                1,
                 "div",
                 vec![],
-                vec![Proto::Element(Element::new("span", vec![], vec![]))]
+                vec![Proto::Element(Element::new(2, "span", vec![], vec![]))]
             )))
         );
     }


### PR DESCRIPTION
Remove individual element token types and replace them with an identifier. This is necessary to distinguish between elements and variables in the future. The checks to see if an identifier is an element are now determined during parsing where the additional context is needed.