### PR TITLE
Transpiler render update

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,18 @@ form {
     @method="POST"
 
     input {
-	    @type="email"
-	    @placeholder="Email"
+        @type="email"
+        @placeholder="Email"
     }
 
     input {
-	    @type="password"
-	    @placeholder="Password"
+        @type="password"
+        @placeholder="Password"
     }
 
     button {
-	    @type="submit"
-	    "Login"
+        @type="submit"
+        "Login"
     }
 }
 ```
@@ -86,7 +86,7 @@ function dom(target) {
     let input3 = element("input");
     let button4 = element("button");
     let t5 = literal("Login");
-	attribute(form1, "method", "POST");
+    attribute(form1, "method", "POST");
     attribute(input2, "type", "email");
     attribute(input2, "placeholder", "Email");
     attribute(input3, "type", "password");

--- a/README.md
+++ b/README.md
@@ -44,15 +44,10 @@ form {
 
 ```
 program := element
-element := ('div'
-    | 'span'
-    | 'p'
-    | 'form'
-    | 'input'
-    | 'button'
-) element_block | LITERAL
-element_block := '{' (element | attribute)* '}'
-attribute := '@' LITERAL '=' LITERAL ';'
+element := html_tag '{' (element | attribute)* '}' | literal
+html_tag := 'div' | 'span' | 'p' | 'form' | 'input' | 'button'
+attribute := '@' literal '=' literal
+literal := STRING
 ```
 
 ## How
@@ -62,28 +57,49 @@ From introduces a build step for creating frontend applications that transforms 
 Take the following From code:
 
 ```
-div {
-    @class="flex"
-    "Hello, 🌎!"
-    span {}
+form {
+    @method="POST"
+
+    input {
+	    @type="email"
+	    @placeholder="Email"
+    }
+
+    input {
+	    @type="password"
+	    @placeholder="Password"
+    }
+
+    button {
+	    @type="submit"
+	    "Login"
+    }
 }
 ```
 
 This is transformed into:
 
 ```js
-function dom() {
-    return element(
-        "div",
-        {
-            class: "flex"
-        },
-        literal("Hello, 🌎!"),
-        element("span", {})
-    )
+function dom(target) {
+    let form1 = element("form");
+    let input2 = element("input");
+    let input3 = element("input");
+    let button4 = element("button");
+    let t5 = literal("Login");
+	attribute(form1, "method", "POST");
+    attribute(input2, "type", "email");
+    attribute(input2, "placeholder", "Email");
+    attribute(input3, "type", "password");
+    attribute(input3, "placeholder", "Password");
+    attribute(button4, "type", "submit");
+    append(target, form1);
+    append(form1, input2);
+    append(form1, input3);
+    append(form1, button4);
+    append(button4, t5);
 }
 ```
-The From runtime library provides the `element` and `literal` function declarations.
+The From runtime library provides the `element`, `literal`, `attribute` and `append` function declarations.
 
 ## Usage
 

--- a/code_generation/src/lib.rs
+++ b/code_generation/src/lib.rs
@@ -65,7 +65,7 @@ impl JsVisitor<String> for CodeGenerator {
             .collect::<Vec<String>>()
             .join(", ");
 
-        format!("{callee}({arguments})")
+        format!("{callee}({arguments});")
     }
 
     fn visit_member_expression(&self, member_expression: &MemberExpression) -> String {
@@ -111,7 +111,7 @@ impl JsVisitor<String> for CodeGenerator {
         let identifier = identifier.accept(self);
 
         let initialiser = match initialiser {
-            Some(initialiser) => format!(" = {};", initialiser.accept(self)),
+            Some(initialiser) => format!(" = {}", initialiser.accept(self)),
             None => ";".to_string(),
         };
 

--- a/code_generation/src/lib.rs
+++ b/code_generation/src/lib.rs
@@ -30,14 +30,21 @@ impl JsVisitor<String> for CodeGenerator {
 
     fn visit_function_declaration(&self, function_declaration: &FunctionDeclaration) -> String {
         let FunctionDeclaration {
-            identifier, body, ..
+            identifier,
+            body,
+            parameters,
+            ..
         } = function_declaration;
 
         let identifier = identifier.accept(self);
-
         let body = body.accept(self);
+        let parameters = parameters
+            .into_iter()
+            .map(|parameter| parameter.accept(self))
+            .collect::<Vec<String>>()
+            .join(", ");
 
-        format!("function {identifier}() {{{body}}}")
+        format!("function {identifier}({parameters}) {{{body}}}")
     }
 
     fn visit_identifier(&self, identifier: &Identifier) -> String {
@@ -177,7 +184,7 @@ mod code_generation {
     #[test]
     fn generate_call_expression_with_members() {
         assert_eq!(
-            r#"document.main.createElement("div")"#,
+            r#"document.main.createElement("div");"#,
             CodeGenerator.generate(&JsNode::CallExpression(CallExpression::new(
                 JsNode::MemberExpression(MemberExpression::new(
                     JsNode::Identifier(Identifier::new("document")),
@@ -197,7 +204,7 @@ mod code_generation {
     #[test]
     fn generate_call_expression() {
         assert_eq!(
-            r#"document.createElement("div")"#,
+            r#"document.createElement("div");"#,
             CodeGenerator.generate(&JsNode::CallExpression(CallExpression::new(
                 JsNode::MemberExpression(MemberExpression::new(
                     JsNode::Identifier(Identifier::new("document")),
@@ -225,6 +232,7 @@ mod code_generation {
             CodeGenerator.generate(&JsNode::FunctionDeclaration(FunctionDeclaration::new(
                 Identifier::new("xyz"),
                 BlockStatement::new(vec![]),
+                vec![]
             )))
         );
     }

--- a/code_generation/src/lib.rs
+++ b/code_generation/src/lib.rs
@@ -109,9 +109,13 @@ impl JsVisitor<String> for CodeGenerator {
         } = variable_declarator;
 
         let identifier = identifier.accept(self);
-        let initialiser = initialiser.accept(self);
 
-        format!("{identifier} = {initialiser}")
+        let initialiser = match initialiser {
+            Some(initialiser) => format!(" = {};", initialiser.accept(self)),
+            None => ";".to_string(),
+        };
+
+        format!("{identifier}{initialiser}")
     }
 
     fn visit_null_literal(&self, null_literal: &NullLiteral) -> String {
@@ -164,7 +168,7 @@ mod code_generation {
                 VariableDeclarationKind::Let,
                 vec![JsNode::VariableDeclarator(VariableDeclarator::new(
                     Identifier::new("x"),
-                    JsNode::StringLiteral(StringLiteral::new("\"hello\""))
+                    Some(JsNode::StringLiteral(StringLiteral::new("\"hello\"")))
                 )),]
             )))
         )

--- a/estree/src/function_declaration.rs
+++ b/estree/src/function_declaration.rs
@@ -7,14 +7,16 @@ pub struct FunctionDeclaration {
     pub js_node_type: JsNodeType,
     pub identifier: Box<JsNode>,
     pub body: Box<JsNode>,
+    pub parameters: Vec<JsNode>,
 }
 
 impl FunctionDeclaration {
-    pub fn new(identifier: Identifier, body: BlockStatement) -> Self {
+    pub fn new(identifier: Identifier, body: BlockStatement, parameters: Vec<JsNode>) -> Self {
         Self {
             js_node_type: JsNodeType::FunctionDeclaration,
             identifier: Box::new(JsNode::Identifier(identifier)),
             body: Box::new(JsNode::BlockStatement(body)),
+            parameters,
         }
     }
 }

--- a/estree/src/variable_declarator.rs
+++ b/estree/src/variable_declarator.rs
@@ -4,15 +4,15 @@ use crate::{JsNode, identifier::Identifier, js_node_type::JsNodeType};
 pub struct VariableDeclarator {
     pub js_node_type: JsNodeType,
     pub identifier: Box<JsNode>,
-    pub initialiser: Box<JsNode>,
+    pub initialiser: Option<Box<JsNode>>,
 }
 
 impl VariableDeclarator {
-    pub fn new(identifier: Identifier, initialiser: JsNode) -> Self {
+    pub fn new(identifier: Identifier, initialiser: Option<JsNode>) -> Self {
         Self {
             js_node_type: JsNodeType::VariableDeclarator,
             identifier: Box::new(JsNode::Identifier(identifier)),
-            initialiser: Box::new(initialiser),
+            initialiser: initialiser.map(Box::new),
         }
     }
 }

--- a/parser/src/html_tag.rs
+++ b/parser/src/html_tag.rs
@@ -2,32 +2,6 @@ use crate::parser_error::ParserError;
 use std::fmt::Display;
 
 #[derive(Debug)]
-pub struct HtmlElementFactory {
-    id: usize,
-}
-
-impl HtmlElementFactory {
-    pub fn new() -> Self {
-        Self { id: 0 }
-    }
-
-    pub fn create(&mut self, tag_type: &str) -> Result<HtmlElement, ParserError> {
-        self.id += 1;
-
-        Ok(HtmlElement {
-            id: self.id,
-            html_tag: HtmlTag::try_from(tag_type)?,
-        })
-    }
-}
-
-#[derive(Debug)]
-pub struct HtmlElement {
-    pub id: usize,
-    pub html_tag: HtmlTag,
-}
-
-#[derive(Debug)]
 pub enum HtmlTag {
     P,
     Form,

--- a/parser/src/html_tag.rs
+++ b/parser/src/html_tag.rs
@@ -63,6 +63,6 @@ impl Display for HtmlTag {
             HtmlTag::Div => String::from("div"),
             HtmlTag::Span => String::from("span"),
         };
-        write!(f, "\"{}\"", html_tag)
+        write!(f, "{}", html_tag)
     }
 }

--- a/parser/src/id_generator.rs
+++ b/parser/src/id_generator.rs
@@ -1,0 +1,15 @@
+#[derive(Debug)]
+pub struct IdGenerator {
+    id: usize,
+}
+
+impl IdGenerator {
+    pub fn new() -> Self {
+        Self { id: 0 }
+    }
+
+    pub fn generate(&mut self) -> usize {
+        self.id += 1;
+        self.id
+    }
+}

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -150,9 +150,9 @@ mod parser {
         assert_eq!(
             Ok(Proto::Element(Element::new(
                 1,
-                "\"span\"",
+                "span",
                 vec![Proto::Attribute(Attribute::new("style", "\"\"")),],
-                vec![Proto::Element(Element::new(2, "\"div\"", vec![], vec![]))]
+                vec![Proto::Element(Element::new(2, "div", vec![], vec![]))]
             ))),
             Parser::new(r#"span {@style="" div{}}"#).parse(),
         );
@@ -160,7 +160,7 @@ mod parser {
         assert_eq!(
             Ok(Proto::Element(Element::new(
                 1,
-                "\"span\"",
+                "span",
                 vec![Proto::Attribute(Attribute::new("style", "\"\""))],
                 vec![],
             ))),
@@ -173,15 +173,15 @@ mod parser {
         assert_eq!(
             Ok(Proto::Element(Element::new(
                 1,
-                "\"span\"",
+                "span",
                 vec![],
-                vec![Proto::Element(Element::new(2, "\"div\"", vec![], vec![]))]
+                vec![Proto::Element(Element::new(2, "div", vec![], vec![]))]
             ))),
             Parser::new("span{div{}}").parse(),
         );
 
         assert_eq!(
-            Ok(Proto::Element(Element::new(1, "\"div\"", vec![], vec![]))),
+            Ok(Proto::Element(Element::new(1, "div", vec![], vec![]))),
             Parser::new("div {}").parse()
         );
     }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,10 +1,12 @@
 mod parser_error;
-use html_tag::HtmlElementFactory;
+use html_tag::HtmlTag;
+use id_generator::IdGenerator;
 use parser_error::ParserError;
-use proto::{Attribute, Element, Proto};
+use proto::{Attribute, Element, Literal, Proto};
 use token::{Token, TokenType};
 use token_buffer::TokenBuffer;
 mod html_tag;
+mod id_generator;
 mod token_buffer;
 
 ///
@@ -19,14 +21,14 @@ mod token_buffer;
 #[derive(Debug)]
 pub struct Parser {
     token_buffer: TokenBuffer,
-    html_factory: HtmlElementFactory,
+    id_generator: IdGenerator,
 }
 
 impl Parser {
     pub fn new(input: &str) -> Self {
         Self {
             token_buffer: TokenBuffer::new(input),
-            html_factory: HtmlElementFactory::new(),
+            id_generator: IdGenerator::new(),
         }
     }
 
@@ -39,9 +41,16 @@ impl Parser {
     }
 
     fn element(&mut self) -> Result<Proto, ParserError> {
-        let html_element = match &self.next_or_err([TokenType::Literal, TokenType::Identifier])? {
-            Token::Literal(literal) => return Ok(Proto::Literal(literal.to_owned())),
-            Token::Identifier(identifier) => self.html_factory.create(identifier)?,
+        let element_id = self.id_generator.generate();
+
+        let element_type = match &self.next_or_err([TokenType::Literal, TokenType::Identifier])? {
+            Token::Literal(literal) => {
+                return Ok(Proto::Literal(Literal::new(
+                    self.id_generator.generate(),
+                    literal,
+                )));
+            }
+            Token::Identifier(identifier) => HtmlTag::try_from(identifier.as_str())?.to_string(),
             _ => return Err(ParserError::UnexpectedToken),
         };
 
@@ -61,8 +70,8 @@ impl Parser {
         self.next_or_err([TokenType::RightBrace])?;
 
         Ok(Proto::Element(Element::new(
-            html_element.id,
-            &html_element.html_tag.to_string(),
+            element_id,
+            &element_type,
             attributes,
             children,
         )))
@@ -90,7 +99,10 @@ impl Parser {
             _ => return Err(ParserError::UnexpectedToken),
         };
 
-        Ok(Proto::Literal(value))
+        Ok(Proto::Literal(Literal::new(
+            self.id_generator.generate(),
+            &value,
+        )))
     }
 
     fn next_or_err<T>(&mut self, expected_token_types: T) -> Result<Token, ParserError>

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -13,10 +13,10 @@ mod token_buffer;
 /// Grammar
 ///
 /// program := element
-/// element := html_tag '{' (element | attribute)* '}' | LITERAL
+/// element := html_tag '{' (element | attribute)* '}' | literal
 /// html_tag := 'div' | 'span' | 'p' | 'form' | 'input' | 'button'
 /// attribute := '@' literal '=' literal
-/// literal := LITERAL
+/// literal := STRING
 ///
 #[derive(Debug)]
 pub struct Parser {

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -1,14 +1,29 @@
 #[derive(Debug, PartialEq)]
 pub enum Proto {
     Element(Element),
-    Literal(String),
+    Literal(Literal),
     Attribute(Attribute),
 }
 
 pub trait ProtoVisitor<T> {
     fn visit_element(&self, element: &Element) -> T;
-    fn visit_literal(&self, literal: &String) -> T;
+    fn visit_literal(&self, literal: &Literal) -> T;
     fn visit_attribute(&self, attribute: &Attribute) -> T;
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Literal {
+    pub literal_id: usize,
+    pub literal: String,
+}
+
+impl Literal {
+    pub fn new(literal_id: usize, literal: &str) -> Self {
+        Self {
+            literal_id,
+            literal: literal.to_string(),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -54,7 +69,7 @@ impl Proto {
     pub fn accept<T>(&self, visitor: &impl ProtoVisitor<T>) -> T {
         match self {
             Self::Element(element) => visitor.visit_element(element),
-            Self::Literal(string) => visitor.visit_literal(string),
+            Self::Literal(literal) => visitor.visit_literal(literal),
             Self::Attribute(attribute) => visitor.visit_attribute(attribute),
         }
     }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -28,7 +28,7 @@ mod end_to_end {
         let output = CodeGenerator::new().generate(&js_root);
 
         assert_eq!(
-            r#"function dom() {return element("div", {id: "root"}, element("span", {id: "nested"}, literal("Main")))}"#,
+            r#"function dom(target) {let div1 = element("div");let span2 = element("span");let t3 = literal("Main");attribute(div1, "id", "root");attribute(span2, "id", "nested");append(target, div1);append(div1, span2);append(span2, t3);}"#,
             output
         );
     }
@@ -48,7 +48,7 @@ mod end_to_end {
         let output = CodeGenerator::new().generate(&js_root);
 
         assert_eq!(
-            r#"function dom() {return element("div", {}, literal("Hello, 🌎!"), element("span", {}))}"#,
+            r#"function dom(target) {let div1 = element("div");let t2 = literal("Hello, 🌎!");let span3 = element("span");append(target, div1);append(div1, t2);append(div1, span3);}"#,
             output
         );
     }

--- a/transpiler/src/lib.rs
+++ b/transpiler/src/lib.rs
@@ -28,6 +28,7 @@ impl Transpiler {
         JsNode::FunctionDeclaration(FunctionDeclaration::new(
             Identifier::new("dom"),
             BlockStatement::new(block),
+            vec![JsNode::StringLiteral(StringLiteral::new("target"))],
         ))
     }
 
@@ -196,6 +197,7 @@ mod transpiler {
                         ],
                     ))
                 ))]),
+                vec![],
             )),
             Transpiler.transpile(&Proto::Element(Element::new(
                 1,
@@ -227,6 +229,7 @@ mod transpiler {
                         ],
                     ))
                 ))]),
+                vec![]
             )),
             Transpiler.transpile(&Proto::Element(Element::new(
                 1,

--- a/transpiler/src/lib.rs
+++ b/transpiler/src/lib.rs
@@ -153,90 +153,59 @@ impl Transpiler {
 
 #[cfg(test)]
 mod transpiler {
-    use estree::{
-        JsNode, block_statement::BlockStatement, call_expression::CallExpression,
-        function_declaration::FunctionDeclaration, identifier::Identifier,
-        object_expression::ObjectExpression, object_property::ObjectProperty,
-        return_statement::ReturnStatement, string_literal::StringLiteral,
-    };
-    use proto::{Attribute, Literal};
+    use estree::js_node_type::JsNodeType;
+    use proto::Attribute;
 
     use super::*;
 
     #[test]
-    fn z() {
-        let _r = Transpiler.block(&Proto::Element(Element::new(
-            1,
-            "div",
-            vec![Proto::Attribute(Attribute::new("style", "\"color: red;\""))],
-            vec![Proto::Element(Element::new(
-                2,
-                "span",
-                vec![Proto::Attribute(Attribute::new("class", "\"flex\""))],
-                vec![Proto::Literal(Literal::new(1, "Hello World!"))],
-            ))],
-        )));
-    }
-
-    #[test]
-    fn transpile_elements_with_attributes() {
+    fn transpile_element() {
         assert_eq!(
-            JsNode::FunctionDeclaration(FunctionDeclaration::new(
-                Identifier::new("dom"),
-                BlockStatement::new(vec![JsNode::ReturnStatement(ReturnStatement::new(
-                    JsNode::CallExpression(CallExpression::new(
-                        JsNode::Identifier(Identifier::new("element")),
-                        vec![
-                            JsNode::StringLiteral(StringLiteral::new("div")),
-                            JsNode::ObjectExpression(ObjectExpression::new(vec![
-                                JsNode::ObjectProperty(ObjectProperty::new(
-                                    "style",
-                                    "\"color: red;\""
-                                ))
-                            ])),
-                        ],
-                    ))
-                ))]),
-                vec![],
+            JsNode::CallExpression(CallExpression::new(
+                JsNode::Identifier(Identifier::new("element")),
+                vec![JsNode::StringLiteral(StringLiteral {
+                    js_node_type: JsNodeType::StringLiteral,
+                    value: "\"div\"".to_string(),
+                })],
             )),
-            Transpiler.transpile(&Proto::Element(Element::new(
+            Transpiler.visit_element(&Element::new(
                 1,
                 "div",
-                vec![Proto::Attribute(Attribute::new("style", "\"color: red;\"")),],
-                vec![],
-            )))
+                vec![Proto::Attribute(Attribute::new(
+                    "\"style\"",
+                    "\"color: red;\""
+                )),],
+                vec![]
+            ))
         );
     }
 
     #[test]
-    fn transpile_elements() {
+    fn transpile_literal() {
         assert_eq!(
-            JsNode::FunctionDeclaration(FunctionDeclaration::new(
-                Identifier::new("dom"),
-                BlockStatement::new(vec![JsNode::ReturnStatement(ReturnStatement::new(
-                    JsNode::CallExpression(CallExpression::new(
-                        JsNode::Identifier(Identifier::new("element")),
-                        vec![
-                            JsNode::StringLiteral(StringLiteral::new("div")),
-                            JsNode::ObjectExpression(ObjectExpression::new(vec![])),
-                            JsNode::CallExpression(CallExpression::new(
-                                JsNode::Identifier(Identifier::new("element")),
-                                vec![
-                                    JsNode::StringLiteral(StringLiteral::new("span")),
-                                    JsNode::ObjectExpression(ObjectExpression::new(vec![])),
-                                ],
-                            )),
-                        ],
-                    ))
-                ))]),
-                vec![]
+            JsNode::CallExpression(CallExpression::new(
+                JsNode::Identifier(Identifier::new("literal")),
+                vec![JsNode::StringLiteral(StringLiteral {
+                    js_node_type: JsNodeType::StringLiteral,
+                    value: "Hello, 🌎!".to_string(),
+                })],
             )),
-            Transpiler.transpile(&Proto::Element(Element::new(
-                1,
-                "div",
-                vec![],
-                vec![Proto::Element(Element::new(2, "span", vec![], vec![]))]
-            )))
+            Transpiler.visit_literal(&Literal::new(1, "Hello, 🌎!"))
+        );
+    }
+
+    #[test]
+    fn transpile_attribute() {
+        assert_eq!(
+            JsNode::CallExpression(CallExpression::new(
+                JsNode::Identifier(Identifier::new("attribute")),
+                vec![
+                    JsNode::StringLiteral(StringLiteral::new("div1")),
+                    JsNode::StringLiteral(StringLiteral::new("\"class\"")),
+                    JsNode::StringLiteral(StringLiteral::new("flex"))
+                ],
+            )),
+            Transpiler.visit_attribute(&Attribute::new("class", "flex"), "div1")
         );
     }
 }

--- a/transpiler/src/lib.rs
+++ b/transpiler/src/lib.rs
@@ -95,6 +95,7 @@ impl Transpiler {
                     )));
                 }
                 Proto::Attribute(attribute) => {
+                    // Handle unwrap
                     block.push(self.visit_attribute(attribute, &parent_id.unwrap()))
                 }
             }

--- a/transpiler/src/lib.rs
+++ b/transpiler/src/lib.rs
@@ -83,7 +83,7 @@ impl Transpiler {
         JsNode::CallExpression(CallExpression::new(
             JsNode::Identifier(Identifier::new("element")),
             vec![JsNode::StringLiteral(StringLiteral::new(
-                &element.element_type,
+                format!("\"{}\"", &element.element_type).as_str(),
             ))],
         ))
     }


### PR DESCRIPTION
Change the transpiler output to be more Svelte-like. This means flattening the proto AST with breadth-traversal when converting between proto and estree.

The output now looks like:

```js
// target = document.body
function dom(target) {
    let div1 = element("div");
    let t2 = literal("Hi");
    let span3 = element("span");
    let t4 = literal("Main");
    attribute(div1, "id", "root");
    attribute(span3, "id", "nested");
    append(target, div1);
    append(div1, t2);
    append(div1, span3);
    append(span3, t4);
}
```
Instead of:

```js
function dom() {
    return element(
        "div",
        {
            class: "flex"
        },
        literal("Hello, 🌎!"),
        element("span", {})
    )
}
```

The benefit of doing so is that the runtime code can be simplified, removing the need for a virtual dom and managing state later will be easier 🤞